### PR TITLE
Add the ability to have custom collectors and type collectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog for the gruf-prometheus gem.
 
 ### Pending Release
 
+- Add the ability to have custom collectors and type collectors
+
 ### 1.1.0
 
 - Refactor collector/type collector to utilize new base abstractions

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ You can further configure via bc-prometheus-ruby with:
 | process_label | The label to use for metric prefixing | grpc |
 | process_name | Label to use for process name in logging | grpc | 	
 | collection_frequency | The period in seconds in which to collect metrics | 30 |
+| collectors | Any collectors you would like to start with the server. Passed as a hash of collector class => options | {} |
+| type_collectors | Any type collectors you would like to start with the server. Passed as an array of collector objects | [] |
         
 ## License
 

--- a/lib/gruf/prometheus/collector.rb
+++ b/lib/gruf/prometheus/collector.rb
@@ -21,10 +21,6 @@ module Gruf
     # Prometheus instrumentor for gRPC servers
     #
     class Collector < Bigcommerce::Prometheus::Collectors::Base
-      def type
-        'grpc'
-      end
-
       def collect(metrics = {})
         metrics[:type] = 'grpc'
         rpc_server = grpc_server

--- a/lib/gruf/prometheus/configuration.rb
+++ b/lib/gruf/prometheus/configuration.rb
@@ -24,7 +24,9 @@ module Gruf
       VALID_CONFIG_KEYS = {
         process_label: 'grpc',
         process_name: 'grpc',
-        collection_frequency: 30
+        collection_frequency: 30,
+        type_collectors: [],
+        collectors: []
       }.freeze
 
       attr_accessor *VALID_CONFIG_KEYS.keys

--- a/spec/demo/client
+++ b/spec/demo/client
@@ -1,4 +1,7 @@
-# Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Copyright (c) 2019-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
 # documentation files (the "Software"), to deal in the Software without restriction, including without limitation the
@@ -13,20 +16,34 @@
 # COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 # OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
-require_relative 'rpc/ThingService_services_pb'
-require_relative 'rpc/Error_pb'
+$LOAD_PATH.unshift File.expand_path('../../../lib', __FILE__)
+require 'gruf/prometheus'
+require_relative 'thing_controller'
+require_relative '../support/custom_type_collector'
+require_relative '../support/custom_collector'
+require 'logger'
+ENV['PROCESS'] = 'demo'
 
-class ThingController < ::Gruf::Controllers::Base
-  bind ::Rpc::ThingService::Service
+logger = ::Logger.new(STDOUT)
+logger.level = ::Logger::Severity::DEBUG
 
-  def get_thing
-    collector.bar_it_up(total: rand(1_000))
-    Rpc::GetThingResponse.new(thing: Rpc::Thing.new(id: request.message.id, name: 'Johnny'))
-  end
-
-  private
-
-  def collector
-    @collector ||= ::CustomCollector.new
-  end
+::Bigcommerce::Prometheus.configure do |c|
+  c.server_port = 8_622
+  c.server_host = '0.0.0.0'
+  c.logger = logger
 end
+
+::Gruf.configure do |c|
+  c.logger = logger
+  c.grpc_logger = logger
+  c.server_binding_url = '0.0.0.0:8621'
+  c.hooks.use(
+    Gruf::Prometheus::Hook,
+    type_collectors: [CustomTypeCollector.new]
+  )
+end
+
+client = Gruf::Client.new(service: ::Rpc::ThingService, options: { hostname: '0.0.0.0:8621' })
+resp = client.call(:GetThing)
+
+logger.info resp.message

--- a/spec/demo/server
+++ b/spec/demo/server
@@ -19,6 +19,8 @@
 $LOAD_PATH.unshift File.expand_path('../../../lib', __FILE__)
 require 'gruf/prometheus'
 require_relative 'thing_controller'
+require_relative '../support/custom_type_collector'
+require_relative '../support/custom_collector'
 require 'logger'
 ENV['PROCESS'] = 'demo'
 
@@ -34,7 +36,15 @@ end
 ::Gruf.configure do |c|
   c.logger = logger
   c.grpc_logger = logger
-  c.hooks.use(Gruf::Prometheus::Hook)
+  c.server_binding_url = '0.0.0.0:8621'
+  c.hooks.use(Gruf::Prometheus::Hook,
+    type_collectors: [
+      CustomTypeCollector.new(type: 'custom')
+    ],
+    collectors: {
+      CustomCollector => { type: 'custom' }
+    }
+  )
 end
 
 cli = Gruf::Cli::Executor.new(logger: logger)

--- a/spec/gruf/prometheus/collector_spec.rb
+++ b/spec/gruf/prometheus/collector_spec.rb
@@ -23,7 +23,7 @@ describe Gruf::Prometheus::Collector do
   let(:pool) { TestGrpcPool.new }
   let(:server) { TestGrufServer.new(pool: pool) }
   let(:frequency) { 1 }
-  let(:collector) { described_class.new(client: client, frequency: frequency, options: { server: server }) }
+  let(:collector) { described_class.new(client: client, frequency: frequency, options: { server: server }, type: 'grpc') }
 
   describe '#start' do
     subject { described_class.start(client: client, frequency: 1, options: { server: server }) }

--- a/spec/gruf/prometheus/hook_spec.rb
+++ b/spec/gruf/prometheus/hook_spec.rb
@@ -48,6 +48,37 @@ describe Gruf::Prometheus::Hook do
         subject
       end
     end
+
+    context 'if custom collectors are passed' do
+      let(:options) { { collectors: collectors } }
+      let(:collectors) do
+        {
+          CustomCollector => { type: 'custom' }
+        }
+      end
+
+      it 'should call start on all of them' do
+        expect(logger).to_not receive(:error)
+        expect(CustomCollector).to receive(:start).once
+        expect(prom_server).to receive(:start).once
+        subject
+      end
+    end
+
+    context 'if custom type collectors are passed' do
+      let(:options) { { type_collectors: type_collectors } }
+      let(:custom_collector) { CustomTypeCollector.new }
+      let(:type_collectors) { [custom_collector] }
+
+      it 'should add each of them - including the defaults - to the server' do
+        expect(logger).to_not receive(:error)
+        expect(prom_server).to receive(:add_type_collector).with(instance_of(::Gruf::Prometheus::TypeCollector)).ordered
+        expect(prom_server).to receive(:add_type_collector).with(instance_of(::PrometheusExporter::Server::ActiveRecordCollector)).ordered
+        expect(prom_server).to receive(:add_type_collector).with(custom_collector).ordered
+        expect(prom_server).to receive(:start).once
+        subject
+      end
+    end
   end
 
   describe '.after_server_stop' do


### PR DESCRIPTION
Adds the ability to have custom type collectors and collectors on the gruf process. This can be achieved like so:

```ruby
Gruf.configure do |c|
  c.hooks.use(Gruf::Prometheus::Hook,
    type_collectors: [
      CustomTypeCollector.new(type: 'custom')
    ],
    collectors: {
      CustomCollector => { type: 'custom' }
    }
  )
end
```

Type collectors will automatically get added to the gruf prometheus server. Collectors will automatically have the `.start` class method called against them (which should start their thread as per the base bc-prometheus-ruby collector) when the gruf server starts.

I've added this functionality to the demo server+client as well.

----

@bigcommerce/ruby @bigcommerce/oss-maintainers @bigcommerce/platform-engineering @billthompson  