### PR TITLE
[chore] upgrade bc-prometheus-ruby to v0.3

### DIFF
--- a/gruf-prometheus.gemspec
+++ b/gruf-prometheus.gemspec
@@ -42,5 +42,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry', '>= 0.12'
 
   spec.add_runtime_dependency 'gruf', '>= 2.7'
-  spec.add_runtime_dependency 'bc-prometheus-ruby', '~> 0.2'
+  spec.add_runtime_dependency 'bc-prometheus-ruby', '~> 0.3'
 end


### PR DESCRIPTION
I realized that `gruf-prometheus` gem is using version 0.2 of `bc-prometheus-ruby` 
In this PR, I made a small change to upgrade its version to latest version 0,3