### PR TITLE
Bump bc-prometheus-ruby, add Ruby 2.7 support, drop Ruby < 2.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,24 +13,18 @@ ruby_env: &ruby_env
     - image: circleci/ruby:<<parameters.ruby-version>>
 
 executors:
-  ruby_2_4:
-    <<: *ruby_env
-    parameters:
-      ruby-version:
-        type: string
-        default: "2.4.6"
-  ruby_2_5:
-    <<: *ruby_env
-    parameters:
-      ruby-version:
-        type: string
-        default: "2.5.5"
   ruby_2_6:
     <<: *ruby_env
     parameters:
       ruby-version:
         type: string
-        default: "2.6.3"
+        default: "2.6.6"
+  ruby_2_7:
+    <<: *ruby_env
+    parameters:
+      ruby-version:
+        type: string
+        default: "2.7.1"
 
 commands:
   pre-setup:
@@ -86,7 +80,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: "ruby_2_4"
+        default: "ruby_2_6"
     steps:
       - pre-setup
       - bundle-install
@@ -96,7 +90,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: "ruby_2_4"
+        default: "ruby_2_6"
     steps:
       - pre-setup
       - bundle-install
@@ -106,7 +100,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: "ruby_2_4"
+        default: "ruby_2_6"
     steps:
       - pre-setup
       - bundle-install
@@ -114,25 +108,6 @@ jobs:
 
 workflows:
   version: 2
-  ruby_2_4:
-    jobs:
-      - bundle-audit:
-          name: "ruby-2_4-bundle_audit"
-      - rubocop:
-          name: "ruby-2_4-rubocop"
-      - rspec-unit:
-          name: "ruby-2_4-rspec"
-  ruby_2_5:
-    jobs:
-      - bundle-audit:
-          name: "ruby-2_5-bundle_audit"
-          e: "ruby_2_5"
-      - rubocop:
-          name: "ruby-2_5-rubocop"
-          e: "ruby_2_5"
-      - rspec-unit:
-          name: "ruby-2_5-rspec"
-          e: "ruby_2_5"
   ruby_2_6:
     jobs:
       - bundle-audit:
@@ -144,3 +119,14 @@ workflows:
       - rspec-unit:
           name: "ruby-2_6-rspec"
           e: "ruby_2_6"
+  ruby_2_7:
+    jobs:
+      - bundle-audit:
+          name: "ruby-2_7-bundle_audit"
+          e: "ruby_2_7"
+      - rubocop:
+          name: "ruby-2_7-rubocop"
+          e: "ruby_2_7"
+      - rspec-unit:
+          name: "ruby-2_7-rspec"
+          e: "ruby_2_7"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ Changelog for the gruf-prometheus gem.
 
 ### Pending Release
 
+- Drop Ruby < 2.6 support
+- Bump bc-prometheus-ruby dependency to 0.3
+
 ### 1.2.0
 
 - Add the ability to have custom collectors and type collectors

--- a/gruf-prometheus.gemspec
+++ b/gruf-prometheus.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
 
   spec.files         = Dir['README.md', 'CHANGELOG.md', 'CODE_OF_CONDUCT.md', 'lib/**/*', 'gruf-prometheus.gemspec']
   spec.require_paths = ['lib']
+  spec.required_ruby_version = '>= 2.6'
 
   spec.add_development_dependency 'rake', '>= 10.0'
   spec.add_development_dependency 'rspec', '>= 3.8'
@@ -42,5 +43,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry', '>= 0.12'
 
   spec.add_runtime_dependency 'gruf', '>= 2.7'
-  spec.add_runtime_dependency 'bc-prometheus-ruby', '~> 0.2'
+  spec.add_runtime_dependency 'bc-prometheus-ruby', '~> 0.3'
 end

--- a/script/test
+++ b/script/test
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+bundle install
+bundle exec bundle-audit update
+bundle exec bundle-audit check -v
+bundle exec rubocop -P -c ./.rubocop.yml
+bundle exec rspec


### PR DESCRIPTION
## What?

* Updates bc-prometheus-ruby dependency to 0.3+
* Drops ruby support for Ruby < 2.6
* Adds test support for Ruby 2.7
* Adds help script for testing locally
* Fixes #5 (fyi @namtx this fixes it a little cleaner)

----

@bigcommerce/ruby @bigcommerce/platform-engineering @bigcommerce/oss-maintainers 