### PR TITLE
Bump rubocop to 1.1, fix various cops

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,28 @@
+---
+name: Bug report
+about: File an issue
+
+---
+
+## Please describe the issue
+
+A clear and concise description of what the bug is.
+
+## How to Reproduce
+
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+## What _should_ happen?
+
+Describe what expected behavior should be.
+
+## Anything else we should know?
+
+* gRPC version
+* Ruby version
+* OS
+* Does it occur at certain traffic volumes, payload size, etc

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,13 @@
+---
+name: Feature request
+about: Suggest a new feature
+
+---
+
+## What? Why?
+
+Describe the problem you are occurring and a proposed solution for it.
+
+## Other Notables
+
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,5 @@
+## What? Why?
+
+
+## How was it tested?
+

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,22 +1,24 @@
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.6
+  NewCops: enable
   Exclude:
-    - spec/**/*
+    - spec/gruf/**/*
+    - spec/**/*_pb.rb
     - .bundle/**/*
-    - bin/**/*
     - vendor/**/*
     - tmp/**/*
     - log/**/*
-    - Rakefile
-    - lib/gruf/prometheus/collectors/grpc.rb
-    - gruf-prometheus.gemspec
+require:
+  - rubocop-performance
+  - rubocop-thread_safety
+  - rubocop-packaging
 
 # Allow *VALID_CONFIG_KEYS.keys
 Lint/AmbiguousOperator:
   Enabled: false
 
 # This cop conflicts with other cops
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: false
 
 Metrics/MethodLength:
@@ -24,3 +26,8 @@ Metrics/MethodLength:
 
 Metrics/AbcSize:
   Max: 40
+
+# Exclude gRPC method names in demo
+Naming/AccessorMethodName:
+  Exclude:
+    - spec/demo/**/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog for the gruf-prometheus gem.
 
 - Add server interceptor for measuring counters/histograms for server metrics
 - Add client interceptor for measuring counters/histograms for client metrics
+- Bump Rubocop to 1.1, remove development dependency on null_logger
 
 ### 1.3.0
 

--- a/gruf-prometheus.gemspec
+++ b/gruf-prometheus.gemspec
@@ -15,7 +15,7 @@
 # COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 # OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
-$:.push File.expand_path('../lib', __FILE__)
+$LOAD_PATH.push File.expand_path('lib', __dir__)
 require 'gruf/prometheus/version'
 
 Gem::Specification.new do |spec|
@@ -33,15 +33,19 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.6'
 
-  spec.add_development_dependency 'rake', '>= 10.0'
-  spec.add_development_dependency 'rspec', '>= 3.8'
-  spec.add_development_dependency 'rspec_junit_formatter', '>= 0.4'
-  spec.add_development_dependency 'bundler-audit', '>= 0.6'
-  spec.add_development_dependency 'rubocop', '>= 0.68'
-  spec.add_development_dependency 'simplecov', '>= 0.16'
-  spec.add_development_dependency 'null-logger', '>= 0.1'
-  spec.add_development_dependency 'pry', '>= 0.12'
-
-  spec.add_runtime_dependency 'gruf', '>= 2.7'
+  # Runtime dependencies
   spec.add_runtime_dependency 'bc-prometheus-ruby', '~> 0.3'
+  spec.add_runtime_dependency 'gruf', '>= 2.7'
+
+  # Development dependencies
+  spec.add_development_dependency 'bundler-audit', '>= 0.6'
+  spec.add_development_dependency 'pry', '>= 0.13'
+  spec.add_development_dependency 'rake', '>= 13.0'
+  spec.add_development_dependency 'rspec', '>= 3.10'
+  spec.add_development_dependency 'rspec_junit_formatter', '>= 0.4'
+  spec.add_development_dependency 'rubocop', '>= 1.1'
+  spec.add_development_dependency 'rubocop-packaging', '~> 0.5'
+  spec.add_development_dependency 'rubocop-performance', '~> 1.8'
+  spec.add_development_dependency 'rubocop-thread_safety', '~> 0.3'
+  spec.add_development_dependency 'simplecov', '>= 0.19'
 end

--- a/spec/demo/client
+++ b/spec/demo/client
@@ -16,7 +16,7 @@
 # COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 # OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
-$LOAD_PATH.unshift File.expand_path('../../../lib', __FILE__)
+$LOAD_PATH.unshift File.expand_path('../../lib', __dir__)
 require 'gruf/prometheus'
 require_relative 'thing_controller'
 require_relative '../support/custom_type_collector'
@@ -24,7 +24,7 @@ require_relative '../support/custom_collector'
 require 'logger'
 ENV['PROCESS'] = 'demo'
 
-logger = ::Logger.new(STDOUT)
+logger = ::Logger.new($stdout)
 logger.level = ::Logger::Severity::DEBUG
 
 ::Bigcommerce::Prometheus.configure do |c|

--- a/spec/demo/rpc/ThingService.proto
+++ b/spec/demo/rpc/ThingService.proto
@@ -34,7 +34,7 @@ message Thing {
 
 // Requests
 
-// Request for geting a single thing
+// Request for getting a single thing
 message GetThingRequest {
     uint32 id = 1;
     uint32 sleep = 2;

--- a/spec/demo/server
+++ b/spec/demo/server
@@ -16,7 +16,7 @@
 # COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 # OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
-$LOAD_PATH.unshift File.expand_path('../../../lib', __FILE__)
+$LOAD_PATH.unshift File.expand_path('../../lib', __dir__)
 require 'gruf/prometheus'
 require_relative 'thing_controller'
 require_relative '../support/custom_type_collector'
@@ -24,7 +24,7 @@ require_relative '../support/custom_collector'
 require 'logger'
 ENV['PROCESS'] = 'demo'
 
-logger = ::Logger.new(STDOUT)
+logger = ::Logger.new($stdout)
 logger.level = ::Logger::Severity::DEBUG
 
 ::Bigcommerce::Prometheus.configure do |c|
@@ -37,10 +37,9 @@ end
   c.logger = logger
   c.grpc_logger = logger
   c.server_binding_url = '0.0.0.0:8621'
-  c.hooks.use(Gruf::Prometheus::Hook,
-    type_collectors: [
-      CustomTypeCollector.new(type: 'custom')
-    ],
+  c.hooks.use(
+    Gruf::Prometheus::Hook,
+    type_collectors: [CustomTypeCollector.new(type: 'custom')],
     collectors: {
       CustomCollector => { type: 'custom' }
     }

--- a/spec/demo/thing_controller.rb
+++ b/spec/demo/thing_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2017-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,19 +16,15 @@
 # OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
 ENV['RACK_ENV'] = 'test'
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
-$LOAD_PATH.unshift File.expand_path('../pb', __FILE__)
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
+$LOAD_PATH.unshift File.expand_path('pb', __dir__)
 require_relative 'simplecov_helper'
 require 'gruf/prometheus'
 require 'pry'
 
-Dir["#{File.join(File.dirname(__FILE__), 'support')}/**/*.rb"].each {|f| require f }
+Dir["#{File.join(File.dirname(__FILE__), 'support')}/**/*.rb"].sort.each { |f| require f }
 
 RSpec.configure do |config|
-  config.alias_example_to :fit, focus: true
-  config.filter_run focus: true
-  config.filter_run_excluding broken: true
-  config.run_all_when_everything_filtered = true
   config.expose_current_running_example_as :example
   config.mock_with :rspec do |mocks|
     mocks.allow_message_expectations_on_nil = true
@@ -37,5 +33,5 @@ RSpec.configure do |config|
 end
 
 Bigcommerce::Prometheus.configure do |c|
-  c.logger = NullLogger.new
+  c.logger = Logger.new(File::NULL)
 end

--- a/spec/support/custom_collector.rb
+++ b/spec/support/custom_collector.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2020-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/spec/support/custom_type_collector.rb
+++ b/spec/support/custom_type_collector.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Copyright (c) 2020-present, BigCommerce Pty. Ltd. All rights reserved
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated

--- a/spec/support/grpc.rb
+++ b/spec/support/grpc.rb
@@ -18,18 +18,18 @@
 require_relative '../pb/ThingService_services_pb'
 
 class TestGrpcPool
-  attr_reader :jobs_waiting, :ready_workers, :workers, :pool_size, :poll_period
+  attr_reader :jobs_waiting,
+              :ready_workers,
+              :workers,
+              :pool_size,
+              :poll_period
 
-  def initialize(jobs_waiting: 0, ready_workers: [], workers: [], pool_size: 10, poll_period: 30)
-    @jobs_waiting = jobs_waiting
-    @ready_workers = ready_workers
-    @workers = workers
-    @pool_size = pool_size
-    @poll_period = poll_period
-  end
-
-  def jobs_waiting
-    @jobs_waiting
+  def initialize(jobs_waiting: nil, ready_workers: nil, workers: nil, pool_size: nil, poll_period: nil)
+    @jobs_waiting = jobs_waiting || 0
+    @ready_workers = ready_workers || []
+    @workers = workers || []
+    @pool_size = pool_size || 10
+    @poll_period = poll_period || 30
   end
 end
 
@@ -44,8 +44,9 @@ end
 
 class TestGrufServer < ::Gruf::Server
   def initialize(server: nil, pool: nil, options: {})
-    pool = pool || TestGrpcPool.new
-    server = server || TestRpcServer.new(pool: pool)
+    pool ||= TestGrpcPool.new
+    server ||= TestRpcServer.new(pool: pool)
+    options ||= {}
 
     super(options)
     @server_mu.synchronize do

--- a/spec/support/logging.rb
+++ b/spec/support/logging.rb
@@ -15,26 +15,16 @@
 # COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 # OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
-require 'null_logger'
-
 module GrufPrometheusLoggerHelper
   def logger
-    Gruf.logger || NullLogger.new
-  end
-end
-class NullLogger
-  def level
-    Logger::Severity::DEBUG
-  end
-  def level=(_lvl)
-    nil
+    Gruf.logger || Logger.new(File::NULL)
   end
 end
 
 RSpec.configure do |config|
   config.before do
-    Gruf.logger = NullLogger.new unless ENV.fetch('DEBUG', 0).to_i.positive?
-    Gruf.grpc_logger = NullLogger.new unless ENV.fetch('DEBUG', 0).to_i.positive?
+    Gruf.logger = Logger.new(File::NULL) unless ENV.fetch('DEBUG', 0).to_i.positive?
+    Gruf.grpc_logger = Logger.new(File::NULL) unless ENV.fetch('DEBUG', 0).to_i.positive?
   end
 
   include GrufPrometheusLoggerHelper


### PR DESCRIPTION
## What? 

- Bumps rubocop to 1.0
- Fixes various cops (most in spec/)
- Adds Github issue/PR templates for this repo
- Removes NullLogger dev dependency (using `File::NULL` now)

---

@bigcommerce/platform-engineering @bigcommerce/ruby 