### PR TITLE
[Fix] Handle seconds instead of milliseconds

### DIFF
--- a/lib/gruf/prometheus/server/collector.rb
+++ b/lib/gruf/prometheus/server/collector.rb
@@ -51,7 +51,7 @@ module Gruf
         #
         def handled_latency_seconds(request:, result:)
           push(
-            grpc_server_handled_latency_seconds: result.elapsed.to_f,
+            grpc_server_handled_latency_seconds: result.elapsed.to_f / 1_000,
             custom_labels: custom_labels(request: request, result: result)
           )
         end

--- a/spec/gruf/prometheus/server/collector_spec.rb
+++ b/spec/gruf/prometheus/server/collector_spec.rb
@@ -91,7 +91,7 @@ describe Gruf::Prometheus::Server::Collector do
 
     it 'pushes the grpc_server_handled_latency_seconds to the server' do
       expect(collector).to receive(:push).with(
-        grpc_server_handled_latency_seconds: 2.0,
+        grpc_server_handled_latency_seconds: 0.002,
         custom_labels: {
           grpc_method: 'GetThing',
           grpc_service: 'gruf.demo.ThingService',
@@ -108,7 +108,7 @@ describe Gruf::Prometheus::Server::Collector do
 
       it 'pushes the grpc_server_handled_latency_seconds to the server with an unsuccessful code' do
         expect(collector).to receive(:push).with(
-          grpc_server_handled_latency_seconds: 2.0,
+          grpc_server_handled_latency_seconds: 0.002,
           custom_labels: {
             grpc_method: 'GetThing',
             grpc_service: 'gruf.demo.ThingService',


### PR DESCRIPTION
## Problem

`Gruf::Prometheus::Server::Collector#handled_latency_seconds` uses `Gruf::Interceptors::Timer.time` to measure how many seconds it takes to perform the procedure. But, according to your other gem `Gruf`, the result of calling `time` method represented in milliseconds, not seconds.

So, I fixed the issue by multiplying result by `1_000`


## How was it tested?

Watch at `Grafana` graphs =)

