### PR TITLE
Add support for Ruby 3.1, drop support for Ruby 2.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,15 +10,9 @@ ruby_env: &ruby_env
     RAILS_ENV: test
     RUBY_VERSION: <<parameters.ruby-version>>
   docker:
-    - image: circleci/ruby:<<parameters.ruby-version>>
+    - image: cimg/ruby:<<parameters.ruby-version>>
 
 executors:
-  ruby_2_6:
-    <<: *ruby_env
-    parameters:
-      ruby-version:
-        type: string
-        default: "2.6"
   ruby_2_7:
     <<: *ruby_env
     parameters:
@@ -31,6 +25,12 @@ executors:
       ruby-version:
         type: string
         default: "3.0"
+  ruby_3_1:
+    <<: *ruby_env
+    parameters:
+      ruby-version:
+        type: string
+        default: "3.1"
 
 commands:
   pre-setup:
@@ -38,21 +38,31 @@ commands:
       - add_ssh_keys
       - checkout
   bundle-install:
+    parameters:
+      gem_cache_key:
+        type: string
+        default: "gem-cache-v2"
+      grpc_ruby_build_procs:
+        type: integer
+        default: 4
     steps:
-      - run:
-          name: "Install bundler 1.17.3"
-          command: |
-            echo 'export BUNDLER_VERSION=1.17.3' >> $BASH_ENV
-            source $BASH_ENV
-            gem install bundler:1.17.3
       - restore_cache:
           keys:
-            - gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
-            - gem-cache-{{ arch }}-{{ .Branch }}
-            - gem-cache
-      - run: bundle check || bundle install --path vendor/bundle
+            - <<parameters.gem_cache_key>>-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+            - <<parameters.gem_cache_key>>-{{ arch }}-{{ .Branch }}
+            - <<parameters.gem_cache_key>>
+      - run:
+          name: "bundle install"
+          command: |
+            export GRPC_RUBY_BUILD_PROCS=<<parameters.grpc_ruby_build_procs>>
+            # due to needing GRPC_RUBY_BUILD_PROCS, we need to explicitly install at least this version
+            gem install grpc -v '>= 1.44.0.pre2' --verbose --no-document
+            bundle config set --local path 'vendor/bundle'
+            bundle lock --add-platform x86_64-linux
+            bundle check || bundle install
+            bundle clean
       - save_cache:
-          key: gem-cache-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
+          key: <<parameters.gem_cache_key>>-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
           paths:
             - vendor/bundle
   rspec-unit:
@@ -92,7 +102,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: "ruby_2_6"
+        default: "ruby_2_7"
     steps:
       - pre-setup
       - bundle-install
@@ -102,7 +112,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: "ruby_2_6"
+        default: "ruby_2_7"
     steps:
       - pre-setup
       - bundle-install
@@ -112,7 +122,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: "ruby_2_6"
+        default: "ruby_2_7"
     steps:
       - pre-setup
       - bundle-install
@@ -120,17 +130,6 @@ jobs:
 
 workflows:
   version: 2
-  ruby_2_6:
-    jobs:
-      - bundle-audit:
-          name: "ruby-2_6-bundle_audit"
-          e: "ruby_2_6"
-      - rubocop:
-          name: "ruby-2_6-rubocop"
-          e: "ruby_2_6"
-      - rspec-unit:
-          name: "ruby-2_6-rspec"
-          e: "ruby_2_6"
   ruby_2_7:
     jobs:
       - bundle-audit:
@@ -153,3 +152,14 @@ workflows:
       - rspec-unit:
           name: "ruby-3_0-rspec"
           e: "ruby_3_0"
+  ruby_3_1:
+    jobs:
+      - bundle-audit:
+          name: "ruby-3_1-bundle_audit"
+          e: "ruby_3_1"
+      - rubocop:
+          name: "ruby-3_1-rubocop"
+          e: "ruby_3_1"
+      - rspec-unit:
+          name: "ruby-3_1-rspec"
+          e: "ruby_3_1"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
   NewCops: enable
   Exclude:
     - spec/gruf/**/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ Changelog for the gruf-prometheus gem.
 
 ### Pending Release
 
+- Add Ruby 3.1 support
+- Drop support for Ruby 2.6
+- Add CircleCI test suite for Ruby 3.1
+
 ### 2.1.0
 
 - Add Ruby 3 support

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CircleCI](https://circleci.com/gh/bigcommerce/gruf-prometheus/tree/main.svg?style=svg)](https://circleci.com/gh/bigcommerce/gruf-prometheus/tree/main)  [![Gem Version](https://badge.fury.io/rb/gruf-prometheus.svg)](https://badge.fury.io/rb/gruf-prometheus) [![Documentation](https://inch-ci.org/github/bigcommerce/gruf-prometheus.svg?branch=main)](https://inch-ci.org/github/bigcommerce/gruf-prometheus?branch=main)
 
-Adds Prometheus support for [gruf](https://github.com/bigcommerce/gruf) 2.7.0+.
+Adds Prometheus support for [gruf](https://github.com/bigcommerce/gruf) 2.7.0+. Supports Ruby 2.7-3.1.
 
 ## Installation
 

--- a/gruf-prometheus.gemspec
+++ b/gruf-prometheus.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
 
   spec.files         = Dir['README.md', 'CHANGELOG.md', 'CODE_OF_CONDUCT.md', 'lib/**/*', 'gruf-prometheus.gemspec']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6', '< 3.1'
+  spec.required_ruby_version = '>= 2.7', '< 4'
 
   # Runtime dependencies
   spec.add_runtime_dependency 'bc-prometheus-ruby', '>= 0.5.1'

--- a/spec/support/grpc.rb
+++ b/spec/support/grpc.rb
@@ -45,13 +45,13 @@ end
 class TestGrufServer < ::Gruf::Server
   def initialize(server: nil, pool: nil, options: {})
     pool ||= TestGrpcPool.new
-    server ||= TestRpcServer.new(pool: pool)
     options ||= {}
-
     super(options)
-    @server_mu.synchronize do
-      @server = server
-    end
+    @server ||= TestRpcServer.new(pool: pool)
+  end
+
+  def server
+    @server
   end
 
   def setup


### PR DESCRIPTION
## What? Why?

* Adds support for Ruby 3.1
* Drops support for Ruby 2.6
* Updates CCI image to the cimg/ branch
* Adds CCI suite for Ruby 3.1
* Some spec mocking updates due to gruf 2.13+ changes around server running

## How was it tested?

rspec, manual, CCI.