### PR TITLE
Ensure ActiveRecord collector is started

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog for the gruf-prometheus gem.
 
 ### Pending Release
 
+- Ensure ActiveRecord collector is started on gruf hook
+
 ### 2.3.0
 
 - Add server collector and interceptor for measuring server failures

--- a/gruf-prometheus.gemspec
+++ b/gruf-prometheus.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.description   = spec.summary
   spec.homepage      = 'https://github.com/bigcommerce/gruf-prometheus'
   spec.license       = 'MIT'
+  spec.metadata['rubygems_mfa_required'] = 'true'
 
   spec.files         = Dir['README.md', 'CHANGELOG.md', 'CODE_OF_CONDUCT.md', 'lib/**/*', 'gruf-prometheus.gemspec']
   spec.require_paths = ['lib']

--- a/lib/gruf/prometheus/hook.rb
+++ b/lib/gruf/prometheus/hook.rb
@@ -63,6 +63,12 @@ module Gruf
           client: ::Bigcommerce::Prometheus.client,
           frequency: ::Gruf::Prometheus.collection_frequency
         )
+        if active_record_enabled?
+          ::PrometheusExporter::Instrumentation::ActiveRecord.start(
+            client: ::Bigcommerce::Prometheus.client,
+            frequency: ::Gruf::Prometheus.collection_frequency
+          )
+        end
         ::Gruf::Prometheus::Collector.start(
           options: {
             server: server
@@ -109,6 +115,15 @@ module Gruf
       #
       def custom_collectors
         @options.fetch(:collectors, []) || []
+      end
+
+      ##
+      # @return [Boolean]
+      #
+      def active_record_enabled?
+        defined?(ActiveRecord) && ::ActiveRecord::Base.connection_pool.respond_to?(:stat)
+      rescue StandardError => _e
+        false
       end
     end
   end

--- a/spec/support/grpc.rb
+++ b/spec/support/grpc.rb
@@ -43,15 +43,13 @@ class TestRpcServer
 end
 
 class TestGrufServer < ::Gruf::Server
+  attr_reader :server
+
   def initialize(server: nil, pool: nil, options: {})
     pool ||= TestGrpcPool.new
     options ||= {}
     super(options)
-    @server ||= TestRpcServer.new(pool: pool)
-  end
-
-  def server
-    @server
+    @server = server || TestRpcServer.new(pool: pool)
   end
 
   def setup


### PR DESCRIPTION
## What? Why?

Ensure the AR collector is started in the Gruf hook so that we can have ActiveRecord metrics for grpc processes.

## How was it tested?

Locally, rspec, and in a service. Works now as expected:

```
# HELP active_record_connection_pool_connections Total connections in pool
# TYPE active_record_connection_pool_connections gauge
active_record_connection_pool_connections{pool_name="primary",pid="41615"} 0

# HELP active_record_connection_pool_busy Connections in use in pool
# TYPE active_record_connection_pool_busy gauge
active_record_connection_pool_busy{pool_name="primary",pid="41615"} 0

# HELP active_record_connection_pool_dead Dead connections in pool
# TYPE active_record_connection_pool_dead gauge
active_record_connection_pool_dead{pool_name="primary",pid="41615"} 0

# HELP active_record_connection_pool_idle Idle connections in pool
# TYPE active_record_connection_pool_idle gauge
active_record_connection_pool_idle{pool_name="primary",pid="41615"} 0

# HELP active_record_connection_pool_waiting Connection requests waiting
# TYPE active_record_connection_pool_waiting gauge
active_record_connection_pool_waiting{pool_name="primary",pid="41615"} 0

# HELP active_record_connection_pool_size Maximum allowed connection pool size
# TYPE active_record_connection_pool_size gauge
active_record_connection_pool_size{pool_name="primary",pid="41615"} 5
```