### PR TITLE
Add support for Ruby 3.2, drop support for Ruby 2.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,12 +13,6 @@ ruby_env: &ruby_env
     - image: cimg/ruby:<<parameters.ruby-version>>
 
 executors:
-  ruby_2_7:
-    <<: *ruby_env
-    parameters:
-      ruby-version:
-        type: string
-        default: "2.7"
   ruby_3_0:
     <<: *ruby_env
     parameters:
@@ -31,6 +25,12 @@ executors:
       ruby-version:
         type: string
         default: "3.1"
+  ruby_3_2:
+    <<: *ruby_env
+    parameters:
+      ruby-version:
+        type: string
+        default: "3.2"
 
 commands:
   pre-setup:
@@ -102,7 +102,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: "ruby_2_7"
+        default: "ruby_3_0"
     steps:
       - pre-setup
       - bundle-install
@@ -112,7 +112,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: "ruby_2_7"
+        default: "ruby_3_0"
     steps:
       - pre-setup
       - bundle-install
@@ -122,7 +122,7 @@ jobs:
     parameters:
       e:
         type: executor
-        default: "ruby_2_7"
+        default: "ruby_3_0"
     steps:
       - pre-setup
       - bundle-install
@@ -130,17 +130,6 @@ jobs:
 
 workflows:
   version: 2
-  ruby_2_7:
-    jobs:
-      - bundle-audit:
-          name: "ruby-2_7-bundle_audit"
-          e: "ruby_2_7"
-      - rubocop:
-          name: "ruby-2_7-rubocop"
-          e: "ruby_2_7"
-      - rspec-unit:
-          name: "ruby-2_7-rspec"
-          e: "ruby_2_7"
   ruby_3_0:
     jobs:
       - bundle-audit:
@@ -163,3 +152,14 @@ workflows:
       - rspec-unit:
           name: "ruby-3_1-rspec"
           e: "ruby_3_1"
+  ruby_3_2:
+    jobs:
+      - bundle-audit:
+          name: "ruby-3_2-bundle_audit"
+          e: "ruby_3_2"
+      - rubocop:
+          name: "ruby-3_2-rubocop"
+          e: "ruby_3_2"
+      - rspec-unit:
+          name: "ruby-3_2-rspec"
+          e: "ruby_3_2"

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+* @bigcommerce/ruby
+* @bigcommerce/oss-maintainers

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
   NewCops: enable
   Exclude:
     - spec/gruf/**/*
@@ -31,3 +31,6 @@ Metrics/AbcSize:
 Naming/AccessorMethodName:
   Exclude:
     - spec/demo/**/*
+
+Style/RedundantConstantBase:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ Changelog for the gruf-prometheus gem.
 
 ### Pending Release
 
+- Add support for Ruby 3.2
+- Drop support for Ruby 2.7 (EOL March 2023)
+
 ### 2.3.1
 
 - Ensure ActiveRecord collector is started on gruf hook

--- a/gruf-prometheus.gemspec
+++ b/gruf-prometheus.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
 
   spec.files         = Dir['README.md', 'CHANGELOG.md', 'CODE_OF_CONDUCT.md', 'lib/**/*', 'gruf-prometheus.gemspec']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.7', '< 4'
+  spec.required_ruby_version = '>= 3.0', '< 4'
 
   # Runtime dependencies
   spec.add_runtime_dependency 'bc-prometheus-ruby', '>= 0.5.1'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,7 +22,7 @@ require_relative 'simplecov_helper'
 require 'gruf/prometheus'
 require 'pry'
 
-Dir["#{File.join(File.dirname(__FILE__), 'support')}/**/*.rb"].sort.each { |f| require f }
+Dir["#{File.join(File.dirname(__FILE__), 'support')}/**/*.rb"].each { |f| require f }
 
 RSpec.configure do |config|
   config.expose_current_running_example_as :example


### PR DESCRIPTION
## What? Why?

* Add tested support for Ruby 3.2
* Drops support for Ruby 2.7 (EOL March 2023)

## How was it tested?

rspec, local